### PR TITLE
FRI-127

### DIFF
--- a/script-engine/src/main/java/org/ihtsdo/termserver/scripting/client/TermServerClient.java
+++ b/script-engine/src/main/java/org/ihtsdo/termserver/scripting/client/TermServerClient.java
@@ -661,4 +661,14 @@ public class TermServerClient {
 		}
 	}
 
+	public void setAuthorFlag(String branchPath, String key, String value) throws TermServerScriptException {
+		String url = this.url + "/branches/" + branchPath + "/actions/set-author-flag";
+		Map<String, String> requestBody = Map.of("name", key, "value", value);
+		try {
+			restTemplate.postForObject(url, requestBody, Object.class);
+		} catch (RestClientException e) {
+			throw new TermServerScriptException(translateRestClientException(e));
+		}
+	}
+
 }

--- a/script-engine/src/main/java/org/ihtsdo/termserver/scripting/fixes/BatchFix.java
+++ b/script-engine/src/main/java/org/ihtsdo/termserver/scripting/fixes/BatchFix.java
@@ -297,6 +297,7 @@ public abstract class BatchFix extends TermServerScript implements ScriptConstan
 					task.setKey(scaClient.createTask(project.getKey(), task.getSummary(), taskDescription));
 					debug ("Creating task branch in terminology server: " + task);
 					task.setBranchPath(tsClient.createBranch(project.getBranchPath(), task.getKey()));
+					tsClient.setAuthorFlag(task.getBranchPath(), "batch-change", "true");
 					taskCreated = true;
 				} catch (Exception e) {
 					taskCreationAttempts++;


### PR DESCRIPTION
FRI-127 is concerned with returning certain criteria from authoring-acceptance-gateway whenever a snowstorm branch is flagged as having had content added via a batch process.

Reporting engine will set the appropriate flag after creating the task on jira. This flag will later be picked up by authoring-acceptance-gateway.

[Snowstorm](https://github.com/IHTSDO/snowstorm/pull/328)

[Reporting Engine](https://github.com/IHTSDO/reporting-engine/pull/6)

[Authoring Acceptance Gateway](https://github.com/IHTSDO/authoring-acceptance-gateway/pull/18)