### PR TITLE
RP-585 Add check for missing laterality concepts

### DIFF
--- a/script-engine/src/main/java/org/ihtsdo/termserver/scripting/TermServerScript.java
+++ b/script-engine/src/main/java/org/ihtsdo/termserver/scripting/TermServerScript.java
@@ -996,6 +996,13 @@ public abstract class TermServerScript extends Script implements ScriptConstants
 	public Collection<Concept> findConcepts(String ecl) throws TermServerScriptException {
 		return findConcepts(project.getBranchPath(), ecl, false, true, CharacteristicType.INFERRED_RELATIONSHIP);
 	}
+
+	public Collection<Concept> findConceptsWithoutEffectiveTime(String ecl) throws TermServerScriptException {
+		Collection<Concept> concepts = findConcepts(ecl);
+		concepts.removeIf(Concept::hasEffectiveTime);
+
+		return concepts;
+	}
 	
 	public Collection<RefsetMember> findRefsetMembers(List<Concept> refCompIds, String refsetFilter) throws TermServerScriptException {
 		return tsClient.findRefsetMembers(project.getBranchPath(), refCompIds, refsetFilter);

--- a/script-engine/src/main/java/org/ihtsdo/termserver/scripting/client/TermServerClient.java
+++ b/script-engine/src/main/java/org/ihtsdo/termserver/scripting/client/TermServerClient.java
@@ -235,7 +235,7 @@ public class TermServerClient {
 			url += "&searchAfter=" + searchAfter;
 		}
 
-		url += "&" + eclType + "={criteria}";
+		url += "&" + eclType + "=" + criteria;
 		System.out.println("Calling: " + url + " with criteria = '" + criteria + "'");
 		return restTemplate.getForObject(url, ConceptCollection.class, criteria);
 	}

--- a/script-engine/src/main/java/org/ihtsdo/termserver/scripting/domain/Concept.java
+++ b/script-engine/src/main/java/org/ihtsdo/termserver/scripting/domain/Concept.java
@@ -170,6 +170,10 @@ public class Concept extends Component implements ScriptConstants, Comparable<Co
 		this.effectiveTime = effectiveTime;
 	}
 
+	public boolean hasEffectiveTime() {
+		return effectiveTime != null && !effectiveTime.isEmpty();
+	}
+
 	public String getModuleId() {
 		return moduleId;
 	}


### PR DESCRIPTION
RP-585 is concerned with adding a report to check for missing laterality concepts, i.e. if there is a Left Arm but no corresponding Right Arm.  